### PR TITLE
Add blog post on Layer5 Kanvas for engineers

### DIFF
--- a/src/data/blogPosts.ts
+++ b/src/data/blogPosts.ts
@@ -11,6 +11,82 @@ export interface BlogPost {
 
 export const blogPosts: BlogPost[] = [
   {
+    "id": "layer5-kanvas-google-workspace-for-infra-engineers",
+    "title": "Layer5 Kanvas: The Google Workspace for Infrastructure Engineers",
+    "excerpt": "Discover how Layer5 Kanvas brings real-time collaboration, visual design, and unified management to cloud native infrastructure, much like Google Workspace does for office productivity.",
+    "content": `
+  ## Introduction
+  
+  Just as Google Workspace revolutionized team productivity by enabling seamless real-time collaboration on documents, sheets, and slides, Layer5 Kanvas is transforming how infrastructure engineers and DevOps teams work with cloud native systems. Kanvas provides a collaborative canvas for designing, configuring, and managing Kubernetes and multi-cloud infrastructures—turning complex YAML files and command-line operations into an intuitive, shared visual experience.
+  
+  Layer5 itself describes Kanvas as delivering \"a collaborative experience for engineers similar to how Google Workspace transforms the digital work environment.\"
+  
+  ## What is Layer5 Kanvas?
+  
+  Layer5 Kanvas is a web-based visual designer and collaborative platform built on the open-source Meshery project. It allows teams to create, share, and orchestrate diagrams of cloud native infrastructure using drag-and-drop components representing Kubernetes resources, service meshes, cloud services, and more.
+  
+  Key capabilities include:
+  - Thousands of versioned, semantic components (Deployments, Services, Ingresses, etc.)
+  - Real-time multi-user editing and collaboration
+  - Import from existing configs (Kubernetes manifests, Helm charts, Docker Compose)
+  - Configuration panels for fine-tuning components
+  - Versioning, sharing, and embedding of designs
+  - Integration with Meshery for deployment and operations
+  
+  ## Real-Time Collaboration Like Google Docs
+  
+  One of the strongest parallels to Google Workspace is Kanvas's real-time collaboration:
+  
+  - Multiple engineers can edit the same infrastructure design simultaneously
+  - Changes appear instantly for all participants
+  - Add comments and conduct design reviews directly on the canvas
+  - Team workspaces with access controls and organizational hierarchy
+  
+  This eliminates the bottlenecks of emailing YAML files back and forth or merging conflicting pull requests—just like how Google Docs ended version chaos in document collaboration.
+  
+  ## Drag-and-Drop Design Like Building Slides or Sheets
+  
+  Infrastructure design in Kanvas feels familiar:
+  
+  - Drag components from a rich palette onto the canvas
+  - Connect them to define relationships
+  - Configure properties in side panels
+  - Use freestyle drawing for annotations or custom diagrams
+  
+  It's as intuitive as arranging elements in Google Slides or organizing data in Sheets, but for Pods, Services, and cloud resources instead of text and charts.
+  
+  ## Unified Workspace for Teams
+  
+  Kanvas, powered by Layer5 Cloud, provides:
+  
+  - Centralized catalog of public and private designs/patterns
+  - Team management and permissions
+  - Version history and sharing controls
+  - Embeddable interactive designs in docs or wikis
+  
+  Much like Google Workspace's shared drives, calendars, and apps—all infrastructure artifacts live in one collaborative environment.
+  
+  ## From Design to Deployment
+  
+  While Google Workspace focuses on content creation, Kanvas goes further by bridging design and operations:
+  
+  - Deploy designs directly via Meshery
+  - Validate configurations
+  - Manage running workloads visually
+  
+  This closes the loop for infrastructure engineers, making Kanvas a complete platform for the entire lifecycle.
+  
+  ## Conclusion
+  
+  In an era of increasingly complex cloud native environments, Layer5 Kanvas brings the simplicity and collaboration of Google Workspace to infrastructure teams. By replacing fragmented tools and text-heavy configs with a visual, real-time collaborative platform, Kanvas empowers engineers to design, review, and operate infrastructure more efficiently—together.
+  
+  If you're tired of wrestling with YAML sprawl, give Kanvas a try and experience the future of collaborative infrastructure management.
+    `,
+    "date": "2025-12-17",
+    "readTime": "6 min read",
+    "category": "Cloud Native"
+  },
+  {
     id: "building-scalable-react-apps",
     title: "Building Scalable React Applications",
     excerpt: "Learn the architecture patterns and best practices for building React applications that scale gracefully with your team and codebase.",


### PR DESCRIPTION
Added a new blog post about Layer5 Kanvas, detailing its features and benefits for infrastructure engineers, along with a comparison to Google Workspace.